### PR TITLE
Improve decoder output validation, throughput variability stats, and …

### DIFF
--- a/imread_benchmark/benchmark.py
+++ b/imread_benchmark/benchmark.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 # Bound on retained error strings — enough to triage in the JSON without
 # bloating the file when a decoder rejects a large slice of the dataset.
+_WRAPPER_BUG_EXCEPTIONS = (TypeError, AttributeError, ImportError, ModuleNotFoundError)
 MAX_SKIP_EXAMPLES = 3
 
 # If a decoder fails on every single item it's not "decoder X has a 100% skip
@@ -23,6 +24,15 @@ _ALL_FAILED_TEMPLATE = (
     "First error: {err}. This is treated as a decoder failure, not a skip rate."
 )
 
+def _validate_output(result: Any) -> None:
+    if not isinstance(result, np.ndarray):
+        raise ValueError(f"expected numpy.ndarray, got {type(result).__name__}")
+    if result.ndim != 3:
+        raise ValueError(f"expected 3-D (H, W, 3) array, got shape {result.shape}")
+    if result.shape[2] != 3:
+        raise ValueError(f"expected 3 channels in shape[2], got shape {result.shape}")
+    if result.dtype != np.uint8:
+        raise ValueError(f"expected uint8 dtype, got {result.dtype}")
 
 def _summarise(times_per_run_s: list[float], n_items: int) -> dict[str, Any]:
     """
@@ -41,7 +51,7 @@ def _summarise(times_per_run_s: list[float], n_items: int) -> dict[str, Any]:
 
     return {
         "images_per_second_mean": float(ips_arr.mean()),
-        "images_per_second_std": float(ips_arr.std()),
+        "images_per_second_std": float(ips_arr.std(ddof=1)) if ips_arr.size > 1 else 0.0,
         "images_per_second_p50": float(np.percentile(ips_arr, 50)),
         "images_per_second_p90": float(np.percentile(ips_arr, 90)),
         "images_per_second_p99": float(np.percentile(ips_arr, 99)),
@@ -74,12 +84,15 @@ def _discover_skips(
     examples: list[str] = []
     for idx, item in enumerate(items):
         try:
-            decode_fn(item)
+            result = decode_fn(item)
+            _validate_output(result)
         # Decoder libs raise everything from OSError to ValueError to custom
         # exception types (jpeg4py.JPEGRuntimeError). We genuinely want to
         # catch them all — anything that prevents successful decode of one
         # item is a "skip", regardless of how the library chose to express it.
         except Exception as exc:
+            if isinstance(exc, _WRAPPER_BUG_EXCEPTIONS):
+                raise
             skipped.append(idx)
             if len(examples) < MAX_SKIP_EXAMPLES:
                 examples.append(f"idx={idx}: {type(exc).__name__}: {exc}")


### PR DESCRIPTION
This PR introduces the following improvements:
Decoder output validation: In _discover_skips, added a strict validation for decode_fn(item) output, ensuring it is a (H, W, 3) uint8 NumPy array. Outputs such as CHW, RGBA, float dtype, None, or non-ndarray results will be considered invalid decodes and skipped, preventing incorrect formats from affecting performance statistics. Sample standard deviation for throughput variability: In _summarise, images_per_second_std is changed from population standard deviation (std(ddof=0)) to sample standard deviation (std(ddof=1)). Since benchmark runs are typically limited in sample size, using sample standard deviation is more suitable for estimating performance variability. Single run results will retain 0.0 to avoid nan values. Avoid misclassifying wrapper errors as decode skips: _discover_skips no longer treats wrapper or environment errors as regular decode failures. Exceptions like TypeError, AttributeError, ImportError, ModuleNotFoundError are now re-raised, allowing the issue to be exposed earlier. OSError, ValueError, RuntimeError, and custom decoder exceptions are still logged as decode failures.

## Summary by Sourcery

Strengthen decoder output validation and adjust throughput variability statistics to better reflect benchmark behavior.

Enhancements:
- Validate decoder outputs as (H, W, 3) uint8 NumPy arrays and treat format or dtype mismatches as decode skips.
- Switch throughput variability reporting to use sample standard deviation and handle single-run benchmarks without producing NaNs.
- Differentiate wrapper or environment errors from decoder failures by re-raising likely wrapper bugs instead of counting them as skips.