### PR TITLE
Polish public benchmark documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,22 @@ The `_internal/` directory is **gitignored**. Keep drafts, papers, regenerated p
 
 Nothing under `_internal/` is tracked by git.
 
+## Preparing an anonymous review mirror
+
+The public repository intentionally keeps public identity links. If you need a
+double-blind review artifact, create a separate branch or mirror and remove
+identity surfaces there, not in regular public cleanup PRs.
+
+Checklist for that later anonymous branch:
+
+- remove the GitAds block from `README.md`
+- remove or replace `.github/FUNDING.yml`
+- replace the public citation block in `README.md` with an anonymous artifact note
+- remove direct links to public GitHub profiles, public repository URLs, and author names
+- replace personal or project-specific GCS examples with neutral placeholders if needed
+- verify with `rg -i 'ternaus|iglovikov|vladimir|gitads|github sponsors|2501.13131'`
+- keep `_internal/` ignored; do not publish manuscript drafts by accident
+
 ## Running tests
 
 ```bash
@@ -61,18 +77,18 @@ class FooDecoder(BaseDecoder):
 
 The default `decode_path()` implementation calls `decode(Path(path).read_bytes())`, which is correct for all libraries.
 
-### 2. Register in the registry
+### 2. Register the decoder entry point
 
-In [`imread_benchmark/decoders/__init__.py`](imread_benchmark/decoders/__init__.py):
+In [`pyproject.toml`](pyproject.toml), add an entry under
+`[project.entry-points."imread_benchmark.decoders"]`:
 
-```python
-from imread_benchmark.decoders.foo_decoder import FooDecoder  # add
-
-REGISTRY = {
-    ...
-    "foo": FooDecoder,  # add
-}
+```toml
+entry-points."imread_benchmark.decoders".foo = "imread_benchmark.decoders.foo_decoder:FooDecoder"
 ```
+
+The runtime `REGISTRY` is built from these entry points. Do not hand-edit
+`imread_benchmark/decoders/__init__.py` unless you are changing the registry
+mechanism itself.
 
 ### 3. Add to a dependency group
 
@@ -92,7 +108,7 @@ mainstream = [
 ]
 ```
 
-Add a platform marker if the wheel doesn't build everywhere.
+Add a platform marker if the wheel does not build everywhere.
 
 ### 4. Encode platform skips on the class
 
@@ -143,7 +159,9 @@ tests/
 └── test_utils.py            # utility function tests
 tools/
 ├── analyze_images.py        # dataset statistics
-└── create_plots.py          # generate performance charts
+├── create_plots.py          # generate public README performance charts
+├── paper_assets.py          # generate local paper tables/figures under _internal/
+└── render_readme.py         # refresh benchmark tables in README.md
 pyproject.toml               # 2 dependency groups under [project.optional-dependencies]:
                              #   mainstream / tensorflow
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# Image Loading Benchmark
+# imread-benchmark
 
 ## Overview
 
-Benchmarks the speed of reading JPEG images and converting them to RGB numpy arrays across popular Python libraries. Targets machine learning training pipelines, measured across multiple CPU architectures (Intel Xeon, AMD EPYC, ARM Neoverse, Apple M-series) using the ImageNet validation set.
+`imread-benchmark` is a reproducible benchmark framework for JPEG decoding in Python ML pipelines. It provides:
+
+- an installable `imread-benchmark` CLI for local datasets,
+- isolated per-library worker environments so conflicting stacks can be benchmarked in one run,
+- PyTorch `DataLoader` throughput measurements in addition to single-thread decoder speed,
+- Google Cloud runners for repeatable cloud CPU comparisons, and
+- JSON outputs plus generated plots/tables for README, docs, and publication-ready analysis.
+
+The default benchmark uses the ImageNet validation set and reports RGB `uint8` decode throughput across common Python libraries and CPU families.
 
 ## Results
 
@@ -69,6 +77,18 @@ _**5 platforms** · 50,000 images · 5 runs each · latest run 2026-04-22_
 
 <!-- BENCH:metadata:end -->
 
+### What the results mean
+
+Single-thread decoder speed is useful, but it is not enough to choose a decoder for a training pipeline. The peak `DataLoader` table is usually the better operational signal because it captures multiprocessing worker behavior, library fork-safety, and CPU-specific scaling.
+
+Current headline patterns:
+
+- `simplejpeg` is a strong single-thread baseline and wins peak `DataLoader` throughput on Intel Emerald Rapids and Neoverse N1.
+- `torchvision` wins both AMD platforms at peak `DataLoader` throughput and is effectively tied for first on Neoverse V2.
+- `imageio` is not a single-thread leader, but wins peak `DataLoader` throughput on Neoverse V2 in the current GCP runs.
+- OpenCV is rarely the absolute winner, but is consistently close to the local winner and has successful `DataLoader` results on every platform.
+- PyVips is reported for single-thread decode only; it is skipped in fork-based `DataLoader` benchmarks because of libvips threadpool deadlocks in this harness.
+
 ## GitAds Sponsored
 
 [Sponsored by GitAds](https://gitads.dev/v1/ad-track?source=ternaus/imread_benchmark@github)
@@ -94,10 +114,11 @@ mkdir -p imagenet/val
 tar -xf ILSVRC2012_img_val.tar -C imagenet/val
 ```
 
-## System Requirements (macOS)
+## System Requirements
 
 ```bash
-brew install jpeg-turbo   # required by PyTurboJPEG (pure-python ctypes binding)
+# macOS only: required by PyTurboJPEG (pure-python ctypes binding)
+brew install jpeg-turbo
 ```
 
 `pyvips` ships its own bundled libvips via the `pyvips-binary` PyPI wheel,
@@ -159,10 +180,11 @@ Built venvs are cached in GCS (keyed by `sha256(uv.lock)`), so reruns on the sam
 
 ```
 output/
-└── darwin_Apple-M4-Max/
-    ├── opencv_results.json
-    ├── pillow_results.json
+└── linux_AMD-EPYC-9B45/
+    ├── opencv_1t_results.json
+    ├── opencv_default_results.json
     ├── opencv_dataloader_results.json
+    ├── run_summary.json
     └── ...
 ```
 
@@ -208,18 +230,38 @@ output/
 
 ## Recommendations
 
-### High-throughput ML training
+### Choosing for ML training
 
-- Use `simplejpeg`, `turbojpeg`, or `kornia-rs` for maximum single-thread decode speed
-- Use the DataLoader benchmark to find the best `num_workers` for your CPU
+- Use the DataLoader benchmark for final decoder and `num_workers` selection.
+- Start with OpenCV when you need a robust default that runs everywhere.
+- Try `torchvision` when your pipeline already wants tensors and you can benchmark the target CPU.
+- Try `simplejpeg` / `turbojpeg` / `jpeg4py` when maximum libjpeg-turbo-backed speed matters and your dataset policy handles uncommon JPEG modes.
 
-### Cross-platform
+### Choosing for pure decode speed
 
-- `kornia-rs` and `opencv` offer the most consistent cross-platform performance
+- Use the single-thread table to compare isolated decoder implementations.
+- Re-run locally if your images differ substantially from ImageNet validation JPEGs.
 
-### Feature-rich applications
+### Choosing for feature-rich applications
 
 - `opencv` remains the best choice when you need more than just JPEG decoding
+
+## Paper and Publication Assets
+
+The public README plots are generated under `docs/assets/benchmarks/`:
+
+```bash
+imread-benchmark plot --input output --output docs/assets/benchmarks
+imread-benchmark render-readme
+```
+
+Publication-style tables and figures are generated from the same JSON outputs into ignored local files under `_internal/papers/`:
+
+```bash
+uv run --extra plot python -m tools.paper_assets --all
+```
+
+`_internal/` is intentionally gitignored. Commit the source JSON and public README assets, not local manuscript drafts or generated paper PDFs.
 
 ## Development
 

--- a/docs/gcp_benchmarks.md
+++ b/docs/gcp_benchmarks.md
@@ -1,9 +1,13 @@
 # Running Benchmarks on Google Cloud
 
-The scripts in `gcp/` spin up a Linux x86-64 VM on GCP, run all benchmarks against
-ImageNet from a GCS bucket, upload results back to GCS, and **delete the VM when done**.
-No machine time is wasted. You can start a run, close your laptop, and fetch results
-in the morning.
+The scripts in `gcp/` are the cloud replication framework for `imread-benchmark`.
+They spin up a GCP VM, run the same local `imread-benchmark` CLI against ImageNet
+from a GCS bucket, upload JSON results and logs back to GCS, and **delete the VM
+when done**. No machine time is wasted. You can start a run, close your laptop,
+and fetch results in the morning.
+
+Use this path when you want reproducible CPU comparisons across GCP machine
+families, not just a one-off local benchmark.
 
 ---
 
@@ -262,10 +266,31 @@ Already in the decoder registry. `imread-benchmark run` honors the per-decoder
 platform-skip metadata, so it automatically participates when you launch on a
 matching VM (Linux for jpeg4py).
 
+## Regenerating public and paper assets
+
+After fetching `output/` from GCS, regenerate public README assets with:
+
+```bash
+imread-benchmark plot --input output --output docs/assets/benchmarks
+imread-benchmark render-readme
+```
+
+Publication-style tables and figures use the same JSON outputs but write into the
+ignored `_internal/papers/` workspace:
+
+```bash
+uv run --extra plot python -m tools.paper_assets --all
+```
+
+Do not commit `_internal/` outputs. They are local manuscript artifacts; the
+tracked source of truth is the benchmark JSON plus the generator code.
+
+---
+
 ## Sample size
 
 The defaults (`N=50000`, `--num-runs 5`, `--dl-runs 3`, `--workers "0 2 4 8"`)
-are picked to give paper-grade precision in the smallest wallclock the
+are picked to give publication-grade precision in the smallest wallclock the
 statistics actually justify. Earlier revisions used 50000 × 20 single-thread
 runs and 50000 × 5 dataloader runs across `0 1 2 4 8` workers — that was ~4×
 slower than necessary for zero gain in any number we cite.
@@ -274,10 +299,10 @@ slower than necessary for zero gain in any number we cite.
 
 Full ImageNet val. Two reasons:
 
-1. **No sampling defense in the paper.** "We use the standard ImageNet val
+1. **No sampling defense in a report.** "We use the standard ImageNet val
    set (N = 50 000)" needs no justification. "We sampled 10 000 images" needs
-   a paragraph on selection method, seed, representativeness, and a reviewer
-   asking why N is below the natural unit.
+   a paragraph on selection method, seed, representativeness, and why N is
+   below the natural unit.
 2. **Doesn't drive wallclock anyway.** Per-run time is `N / throughput`. The
    slow decoders (skimage, imageio at ~200 img/s) take ~4 min/run at N=50k;
    cutting N to 10k saves ~3 min/run, but that's the entire decoder's runtime
@@ -293,7 +318,7 @@ error on the *mean throughput* across `N × num_runs` decodes is:
 
 For 50000 × 5 that's ~0.08% relative SE. The interesting effect sizes we
 compare are 2× to 100× (decoder throughput differences). Even 1% SE is more
-precision than the paper can use; 0.08% is theatrical.
+precision than the benchmark decision can use; 0.08% is theatrical.
 
 `num_runs` matters for *per-run percentiles* (p50/p90/p99 across runs), not
 for mean precision. With `num_runs = 5`:
@@ -301,7 +326,7 @@ for mean precision. With `num_runs = 5`:
 - `p50` = median of 5 ≈ stable
 - `p90`, `p99` = essentially the max-of-5, no useful resolution
 
-We dropped these columns from the paper. The headline is `mean ± std img/s`,
+We dropped these columns from publication tables. The headline is `mean ± std img/s`,
 and `num_runs = 5` gives a stable std estimate (5 samples is the practical
 minimum for a non-degenerate sample variance).
 


### PR DESCRIPTION
## Summary by Sourcery

Clarify and expand the public description of the imread-benchmark framework, including how results should be interpreted and how assets are generated.

Documentation:
- Document benchmark capabilities, output formats, and interpretation guidance in the README, including recommendations for decoder selection and benchmark usage.
- Describe how to generate public README plots, publication-style tables, and figures from benchmark JSON outputs in both README and GCP docs.
- Refine and clarify the Google Cloud benchmarking guide, including positioning as a replication framework and updating terminology around publication-grade sampling.

Chores:
- Add contributor guidance for preparing an anonymous review mirror, including a checklist for stripping identity-related artifacts from a separate branch.
- Clarify decoder registration instructions to use pyproject entry points and document additional internal tooling scripts in the project layout.